### PR TITLE
Add command-line PDF to DXF/DWG conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# WiFi-fix
+# PDF → DWG Converter
+
+This project provides a command-line utility that extracts vector content from PDF drawings and exports it into CAD-friendly DXF files, with optional DWG generation when paired with an external converter such as the [ODA File Converter](https://www.opendesign.com/guestfiles/oda_file_converter).
+
+## Features
+
+- Parses PDF vector geometry using [PyMuPDF](https://pymupdf.readthedocs.io/) and recreates it as DXF entities via [ezdxf](https://ezdxf.readthedocs.io/).
+- Supports Bézier curve approximation with configurable precision.
+- Optional text extraction with `TEXT` or `MTEXT` output entities.
+- Command-line interface that can call out to an external DXF→DWG converter.
+
+## Installation
+
+Install the package in a virtual environment together with the required dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+```bash
+pdf-to-dwg input.pdf --dxf output.dxf
+```
+
+To additionally create a DWG file you must provide a converter executable that can process DXF input:
+
+```bash
+pdf-to-dwg input.pdf --dxf output.dxf --dwg output.dwg --dwg-converter /path/to/ODAFileConverter
+```
+
+### Command options
+
+- `--bezier-segments`: control the smoothness of curved paths (default `24`).
+- `--unit-scale`: apply a custom unit conversion (e.g. `1/72` to convert PDF points to inches).
+- `--text-mode`: choose how text is exported (`none`, `text`, or `mtext`).
+- `--dxf-version`: pick the DXF version supported by your CAD workflow.
+
+## Testing
+
+The repository contains unit tests that validate the geometry helpers:
+
+```bash
+pytest
+```
+
+## Limitations
+
+- Raster images embedded in the PDF are ignored.
+- Complex shading patterns and gradient fills are not exported.
+- DWG creation requires an external converter tool.

--- a/pdf_to_dwg/__init__.py
+++ b/pdf_to_dwg/__init__.py
@@ -1,0 +1,9 @@
+"""Utilities for converting PDF drawings into DXF/DWG CAD files."""
+
+from .converters import PdfToCadConverter, ConversionSettings, ConversionResult
+
+__all__ = [
+    "PdfToCadConverter",
+    "ConversionSettings",
+    "ConversionResult",
+]

--- a/pdf_to_dwg/cli.py
+++ b/pdf_to_dwg/cli.py
@@ -1,0 +1,108 @@
+"""Command line interface for converting PDF drawings to DXF / DWG."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .converters import (
+    ConversionSettings,
+    PdfToCadConverter,
+    TextExportMode,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert vector-based PDFs into DXF/DWG CAD files.",
+    )
+    parser.add_argument("pdf", type=Path, help="Input PDF drawing to convert")
+    parser.add_argument(
+        "--dxf",
+        type=Path,
+        help="Output DXF file (defaults to <input>.dxf)",
+    )
+    parser.add_argument(
+        "--dwg",
+        type=Path,
+        help="Optional DWG output path (requires --dwg-converter)",
+    )
+    parser.add_argument(
+        "--dwg-converter",
+        type=Path,
+        help="External converter CLI capable of DXF→DWG (e.g. ODAFileConverter)",
+    )
+    parser.add_argument(
+        "--bezier-segments",
+        type=int,
+        default=24,
+        help="Number of segments used to approximate Bézier curves (default: 24)",
+    )
+    parser.add_argument(
+        "--unit-scale",
+        type=float,
+        default=1.0,
+        help=(
+            "Scale factor applied to all coordinates. "
+            "Use 1/72 to convert PDF points to inches."
+        ),
+    )
+    parser.add_argument(
+        "--text-mode",
+        choices=[mode.value for mode in TextExportMode],
+        default=TextExportMode.TEXT.value,
+        help="How to export PDF text objects (default: text)",
+    )
+    parser.add_argument(
+        "--dxf-version",
+        default="R2010",
+        help="DXF version string supported by ezdxf (default: R2010)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pdf_path: Path = args.pdf
+    if not pdf_path.exists():
+        parser.error(f"Input PDF '{pdf_path}' does not exist")
+
+    output_dxf = args.dxf or pdf_path.with_suffix(".dxf")
+    output_dwg = args.dwg
+    dwg_converter = args.dwg_converter
+
+    if output_dwg and not dwg_converter:
+        parser.error("--dwg requires --dwg-converter to be specified")
+
+    settings = ConversionSettings(
+        pdf_path=pdf_path,
+        output_dxf_path=output_dxf,
+        output_dwg_path=output_dwg,
+        bezier_approximation_segments=args.bezier_segments,
+        unit_scale=args.unit_scale,
+        text_mode=TextExportMode(args.text_mode),
+        dxf_version=args.dxf_version,
+        dwg_converter_cli=dwg_converter,
+    )
+
+    converter = PdfToCadConverter(settings)
+    try:
+        result = converter.convert()
+    except Exception as exc:  # pragma: no cover - CLI level failure
+        parser.exit(status=1, message=f"Conversion failed: {exc}\n")
+
+    print(f"DXF saved to: {result.dxf_path}")
+    if result.dwg_path:
+        print(f"DWG saved to: {result.dwg_path}")
+    if result.warnings:
+        print("Warnings:")
+        for warning in result.warnings:
+            print(f"  - {warning}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/pdf_to_dwg/converters.py
+++ b/pdf_to_dwg/converters.py
@@ -1,0 +1,321 @@
+"""Core conversion workflow for PDF → DXF/DWG."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Iterator, List, Optional, Sequence, Tuple
+import math
+import subprocess
+
+try:  # pragma: no cover - runtime dependency check
+    import fitz  # type: ignore
+except ImportError:  # pragma: no cover - optional for test environments
+    fitz = None  # type: ignore
+
+try:  # pragma: no cover - runtime dependency check
+    import ezdxf  # type: ignore
+except ImportError:  # pragma: no cover - optional for test environments
+    ezdxf = None  # type: ignore
+
+
+Point = Tuple[float, float]
+
+
+class TextExportMode(str, Enum):
+    """Controls how text extracted from the PDF should be exported."""
+
+    NONE = "none"
+    TEXT = "text"
+    MTEXT = "mtext"
+
+
+@dataclass(slots=True)
+class ConversionSettings:
+    """Parameters controlling how the conversion should be performed."""
+
+    pdf_path: Path
+    output_dxf_path: Path
+    output_dwg_path: Optional[Path] = None
+    unit_scale: float = 1.0
+    bezier_approximation_segments: int = 24
+    text_mode: TextExportMode = TextExportMode.TEXT
+    dxf_version: str = "R2010"
+    dwg_converter_cli: Optional[Path] = None
+
+    def ensure_output_directory(self) -> None:
+        """Create output directories if they do not exist."""
+
+        self.output_dxf_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.output_dwg_path is not None:
+            self.output_dwg_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(slots=True)
+class ConversionResult:
+    """Returned after a conversion attempt."""
+
+    dxf_path: Path
+    pages_converted: int
+    dwg_path: Optional[Path] = None
+    warnings: List[str] = field(default_factory=list)
+
+
+class PdfToCadConverter:
+    """Main entry point for converting PDFs into DXF (and optionally DWG)."""
+
+    def __init__(self, settings: ConversionSettings) -> None:
+        self.settings = settings
+
+    def convert(self) -> ConversionResult:
+        """Convert the configured PDF into CAD friendly formats."""
+
+        if fitz is None:
+            raise RuntimeError(
+                "PyMuPDF (the `fitz` module) is required. Install it via `pip install pymupdf`."
+            )
+        if ezdxf is None:
+            raise RuntimeError(
+                "The `ezdxf` package is required. Install it via `pip install ezdxf`."
+            )
+
+        self.settings.ensure_output_directory()
+        doc = fitz.open(self.settings.pdf_path)  # type: ignore[call-arg]
+        try:
+            dxf_path = self.settings.output_dxf_path
+            doc_info = doc.metadata
+            dxf_doc = ezdxf.new(self.settings.dxf_version)
+            if doc_info.get("title"):
+                dxf_doc.header["$PROJECTNAME"] = doc_info["title"]
+            modelspace = dxf_doc.modelspace()
+
+            warnings: List[str] = []
+            for page_index in range(doc.page_count):
+                page = doc.load_page(page_index)
+                page_warnings = self._export_page(page, modelspace)
+                warnings.extend(page_warnings)
+
+            dxf_doc.saveas(dxf_path)
+
+            dwg_path = None
+            if self.settings.output_dwg_path is not None:
+                dwg_path = self._export_dwg_via_cli(dxf_path)
+
+            return ConversionResult(
+                dxf_path=dxf_path,
+                pages_converted=doc.page_count,
+                dwg_path=dwg_path,
+                warnings=warnings,
+            )
+        finally:
+            doc.close()
+
+    # ------------------------------------------------------------------
+    def _export_dwg_via_cli(self, dxf_path: Path) -> Path:
+        """Convert DXF to DWG using an external converter CLI if provided."""
+
+        converter_cli = self.settings.dwg_converter_cli
+        if converter_cli is None:
+            raise RuntimeError(
+                "A DWG output path was specified but no converter CLI was provided."
+            )
+        if not converter_cli.exists():
+            raise FileNotFoundError(f"DWG converter executable '{converter_cli}' not found")
+
+        output_path = self.settings.output_dwg_path
+        assert output_path is not None  # mypy safety
+
+        cmd = [
+            str(converter_cli),
+            str(dxf_path),
+            str(output_path),
+        ]
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - system dep.
+            raise RuntimeError(
+                f"DWG converter failed with exit code {exc.returncode}: {' '.join(cmd)}"
+            ) from exc
+        return output_path
+
+    # ------------------------------------------------------------------
+    def _export_page(self, page: "fitz.Page", modelspace: "ezdxf.layouts.BaseLayout") -> List[str]:
+        """Export a single PDF page into the DXF modelspace."""
+
+        page_warnings: List[str] = []
+        page_height = page.rect.height
+        scale = self.settings.unit_scale
+
+        for drawing in page.get_drawings():
+            try:
+                for polyline in self._iter_polylines(drawing["items"], page_height):
+                    if len(polyline) < 2:
+                        continue
+                    scaled = [(x * scale, y * scale) for x, y in polyline]
+                    is_closed = _is_closed_polyline(polyline)
+                    entity = modelspace.add_polyline2d(
+                        scaled,
+                        dxfattribs={
+                            "layer": f"PDF_PAGE_{page.number + 1}",
+                        },
+                    )
+                    if is_closed:
+                        entity.close(True)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                page_warnings.append(
+                    f"Failed to export vector path on page {page.number + 1}: {exc}"
+                )
+
+        if self.settings.text_mode != TextExportMode.NONE:
+            texts = page.get_text("dict")
+            for block in texts.get("blocks", []):
+                if block.get("type") != 0:
+                    continue
+                for line in block.get("lines", []):
+                    for span in line.get("spans", []):
+                        text = span.get("text", "").strip()
+                        if not text:
+                            continue
+                        x, y = span.get("origin", (0.0, 0.0))
+                        converted_point = self._pdf_to_cad_point((x, y), page_height)
+                        scaled_point = (converted_point[0] * scale, converted_point[1] * scale)
+                        font_height = span.get("size", 12.0) * scale
+                        self._add_text_entity(modelspace, text, scaled_point, font_height)
+
+        return page_warnings
+
+    def _add_text_entity(
+        self,
+        modelspace: "ezdxf.layouts.BaseLayout",
+        text: str,
+        position: Point,
+        height: float,
+    ) -> None:
+        """Insert a text entity into the DXF modelspace based on the configured mode."""
+
+        if self.settings.text_mode == TextExportMode.TEXT:
+            entity = modelspace.add_text(text, dxfattribs={"height": height})
+            entity.set_pos(position, align="LEFT")
+        elif self.settings.text_mode == TextExportMode.MTEXT:
+            mtext = modelspace.add_mtext(text, dxfattribs={"height": height})
+            mtext.set_location(position)
+
+    def _iter_polylines(
+        self,
+        items: Sequence[Sequence[object]],
+        page_height: float,
+    ) -> Iterator[List[Point]]:
+        """Yield polylines extracted from PDF drawing instructions."""
+
+        polyline: List[Point] = []
+        start_point: Optional[Point] = None
+
+        for item in items:
+            if not item:
+                continue
+            cmd = item[0]
+            if cmd == "m":  # move
+                if polyline:
+                    yield polyline
+                point = self._pdf_to_cad_point(item[1], page_height)
+                polyline = [point]
+                start_point = point
+            elif cmd == "l":
+                point = self._pdf_to_cad_point(item[1], page_height)
+                if not polyline:
+                    polyline = [point]
+                    start_point = point
+                else:
+                    polyline.append(point)
+            elif cmd == "c":  # cubic bezier
+                if not polyline:
+                    continue
+                controls = [self._pdf_to_cad_point(ctrl, page_height) for ctrl in item[1:]]
+                bezier_points = approximate_cubic_bezier(
+                    polyline[-1], controls[0], controls[1], controls[2],
+                    segments=self.settings.bezier_approximation_segments,
+                )
+                polyline.extend(bezier_points[1:])
+            elif cmd == "re":  # rectangle
+                rect = item[1]
+                points = [
+                    (rect.x0, rect.y0),
+                    (rect.x1, rect.y0),
+                    (rect.x1, rect.y1),
+                    (rect.x0, rect.y1),
+                    (rect.x0, rect.y0),
+                ]
+                converted = [self._pdf_to_cad_point(p, page_height) for p in points]
+                if polyline:
+                    yield polyline
+                    polyline = []
+                yield converted
+                start_point = None
+            elif cmd == "h":  # close path
+                if polyline and start_point is not None:
+                    polyline.append(start_point)
+            else:
+                # Ignore commands we do not handle explicitly (e.g., quad curves)
+                continue
+
+        if polyline:
+            yield polyline
+
+    def _pdf_to_cad_point(self, point: Sequence[float], page_height: float) -> Point:
+        """Convert a PDF point (origin top-left) into CAD coordinates (origin bottom-left)."""
+
+        x, y = point
+        return (float(x), float(page_height - y))
+
+
+# ----------------------------------------------------------------------
+def approximate_cubic_bezier(
+    p0: Point,
+    p1: Point,
+    p2: Point,
+    p3: Point,
+    *,
+    segments: int = 24,
+) -> List[Point]:
+    """Approximate a cubic Bézier curve with a list of points."""
+
+    if segments < 1:
+        raise ValueError("segments must be >= 1")
+
+    points: List[Point] = []
+    for step in range(segments + 1):
+        t = step / segments
+        mt = 1 - t
+        x = (
+            mt ** 3 * p0[0]
+            + 3 * mt ** 2 * t * p1[0]
+            + 3 * mt * t ** 2 * p2[0]
+            + t ** 3 * p3[0]
+        )
+        y = (
+            mt ** 3 * p0[1]
+            + 3 * mt ** 2 * t * p1[1]
+            + 3 * mt * t ** 2 * p2[1]
+            + t ** 3 * p3[1]
+        )
+        points.append((x, y))
+    return points
+
+
+def _is_closed_polyline(polyline: Sequence[Point]) -> bool:
+    """Return True if the first and last vertex are identical."""
+
+    if len(polyline) < 3:
+        return False
+    first = polyline[0]
+    last = polyline[-1]
+    return math.isclose(first[0], last[0]) and math.isclose(first[1], last[1])
+
+
+__all__ = [
+    "ConversionSettings",
+    "ConversionResult",
+    "PdfToCadConverter",
+    "TextExportMode",
+    "approximate_cubic_bezier",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pdf-to-dwg"
+version = "0.1.0"
+description = "Convert vector PDFs into DXF/DWG CAD files using PyMuPDF and ezdxf"
+authors = [{name = "Auto Generated"}]
+requires-python = ">=3.9"
+dependencies = [
+    "pymupdf>=1.23",
+    "ezdxf>=1.1",
+]
+
+[project.scripts]
+pdf-to-dwg = "pdf_to_dwg.cli:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -1,0 +1,17 @@
+from pdf_to_dwg.converters import approximate_cubic_bezier
+
+
+def test_bezier_returns_expected_number_of_points():
+    points = approximate_cubic_bezier((0.0, 0.0), (1.0, 2.0), (2.0, 3.0), (4.0, 0.0), segments=10)
+    assert len(points) == 11
+    assert points[0] == (0.0, 0.0)
+    assert points[-1] == (4.0, 0.0)
+
+
+def test_bezier_invalid_segments():
+    try:
+        approximate_cubic_bezier((0, 0), (1, 1), (2, 1), (3, 0), segments=0)
+    except ValueError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ValueError for segments < 1")


### PR DESCRIPTION
## Summary
- add a conversion library that exports PDF vector data to DXF and optional DWG output
- provide a command-line interface and packaging metadata for installing the utility
- document usage, features, and project limitations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ff2d4b41948328a96fd95b591fc074